### PR TITLE
Widget refactoring applied. Create one WidgetCommon class and extend it to 4 widget classes.

### DIFF
--- a/app/src/main/java/com/mashupgroup/weatherbear/Global.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/Global.kt
@@ -124,4 +124,17 @@ object Global {
         }
         return result
     }
+
+    /**
+        address 객체가 가지고있는 가장 작은 행정지역 단위 문자열을 가져옴(단, 최소 throughfare)
+     */
+    fun getSmallestLocationString(address: Address): String {
+        if(!address.thoroughfare.isNullOrEmpty()) return address.thoroughfare
+        if(!address.subLocality.isNullOrEmpty()) return address.subLocality
+        if(!address.locality.isNullOrEmpty()) return address.locality
+        if(!address.subAdminArea.isNullOrEmpty()) return address.subAdminArea
+        if(!address.adminArea.isNullOrEmpty()) return address.adminArea
+        if(!address.countryName.isNullOrEmpty()) return address.countryName
+        return "No data"
+    }
 }

--- a/app/src/main/java/com/mashupgroup/weatherbear/Global.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/Global.kt
@@ -135,6 +135,7 @@ object Global {
         if(!address.subAdminArea.isNullOrEmpty()) return address.subAdminArea
         if(!address.adminArea.isNullOrEmpty()) return address.adminArea
         if(!address.countryName.isNullOrEmpty()) return address.countryName
+        if(!address.featureName.isNullOrEmpty()) return address.featureName // feature는 정말 최소행정단위인데, 가끔 '북극'같은경우 feature만 있는경우가있어서..
         return "No data"
     }
 }

--- a/app/src/main/java/com/mashupgroup/weatherbear/MainActivity.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/MainActivity.kt
@@ -2,6 +2,8 @@ package com.mashupgroup.weatherbear
 
 import android.Manifest
 import android.annotation.SuppressLint
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.databinding.DataBindingUtil.setContentView
@@ -28,6 +30,7 @@ import com.mashupgroup.weatherbear.models.weather.Weather
 import com.mashupgroup.weatherbear.viewmodels.BackgroundViewModel
 import com.mashupgroup.weatherbear.viewmodels.BearViewModel
 import com.mashupgroup.weatherbear.viewmodels.IsDayViewModel
+import com.mashupgroup.weatherbear.widget.*
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.schedulers.Schedulers
 import kotlinx.android.synthetic.main.activity_main.*
@@ -129,6 +132,24 @@ class MainActivity : AppCompatActivity() {
             val intent = Intent(this, SelectLocationActivity::class.java)
             startActivityForResult(intent, RESULT_CODE_ADDRESS_MANAGE_ACTIVITY)
         }
+    }
+
+
+    override fun onDestroy() {
+
+        // 앱이 닫힐 때(onDestroy) 모든 위젯을 강제로 업데이트한다
+        arrayOf( WeatherBoxWidget::class.java,
+                 WeatherBoxWidgetBg::class.java,
+                 WeatherBearHeadWidget::class.java,
+                 WeatherBearHeadWidgetBg::class.java).forEach { className ->
+            val intent = Intent(this, className)
+            intent.action = AppWidgetManager.ACTION_APPWIDGET_UPDATE
+            val ids = AppWidgetManager.getInstance(application).getAppWidgetIds(ComponentName(application, className))
+            intent.putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, ids)
+            sendBroadcast(intent)
+        }
+
+        super.onDestroy()
     }
 
     private fun requestCurrentLocationAndUpdateFirstPage() {

--- a/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearHeadWidget.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearHeadWidget.kt
@@ -2,7 +2,6 @@ package com.mashupgroup.weatherbear.widget
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
-import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
@@ -14,85 +13,64 @@ import java.util.*
 /**
  * Implementation of App Widget functionality.
  */
-class WeatherBearHeadWidget : AppWidgetProvider() {
+class WeatherBearHeadWidget : WeatherBearWidgetCommon() {
 
-    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
-        var weather = "HEAVY_SNOW"
-        var fineDustLevel = "좋음"
-        // There may be multiple widgets active, so update all of them
-        for (appWidgetId in appWidgetIds) updateAppWidget(context, appWidgetManager, appWidgetId,
-                weather, fineDustLevel)
-    }
+    override fun updateAppWidget(weatherData : WidgetWeatherData, context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
+        //SNOW, RAINY, THUNDER_RAINY, WIND, CLOUD, SUNNY, HEAVY_SNOW
+        //미세먼지 : 좋음,보통,나쁨.매우나쁨
+        //낮:true 밤:false
+        val weather = weatherData.weather
+        val fineDustLevel = weatherData.fineDustLevel
+        var time = true
+        val date = Date().hours
+        time = date in 6..17
 
-    override fun onEnabled(context: Context) {
-        // Enter relevant functionality for when the first widget is created
-    }
+        var bearSkin = R.drawable.ic_bear_head_01
+        var bearSnow: Int
+        var bearFace: Int
 
-    override fun onDisabled(context: Context) {
-        // Enter relevant functionality for when the last widget is disabled
-    }
+        //홈스크린의 위젯 xml에 대한 인스턴스를 받아온다,
+        val remoteViews = RemoteViews(context.packageName, R.layout.weather_bear_head_widget)
+        //main activity와 위젯간 데이터 교환의 매개채
+        val intent = Intent(context, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(context, 0, intent, 0)
+        remoteViews.setOnClickPendingIntent(R.id.widgetBearHead, pendingIntent)
+        appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
 
-    companion object {
-
-        internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager,
-                                     appWidgetId: Int, nWeather: String, nFineDustLevel: String) {
-
-
-            //SNOW, RAINY, THUNDER_RAINY, WIND, CLOUD, SUNNY, HEAVY_SNOW
-            //미세먼지 : 좋음,보통,나쁨.매우나쁨
-            //낮:true 밤:false
-            val weather = nWeather
-            val fineDustLevel = nFineDustLevel
-            var time = true
-            val date = Date().hours
-            time = date in 6..17
-
-            var bearSkin = R.drawable.ic_bear_head_01
-            var bearSnow: Int
-            var bearFace: Int
-
-            //홈스크린의 위젯 xml에 대한 인스턴스를 받아온다,
-            val remoteViews = RemoteViews(context.packageName, R.layout.weather_bear_head_widget)
-            //main activity와 위젯간 데이터 교환의 매개채
-            val intent = Intent(context, MainActivity::class.java)
-            val pendingIntent = PendingIntent.getActivity(context, 0, intent, 0)
-            remoteViews.setOnClickPendingIntent(R.id.widgetBearHead, pendingIntent)
-            appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
-
-            when (fineDustLevel) {
-                "좋음" -> bearSkin = (R.drawable.ic_bear_head_01)
-                "보통" -> bearSkin = (R.drawable.ic_bear_head_02)
-                "나쁨" -> bearSkin = (R.drawable.ic_bear_head_03)
-                "매우나쁨" -> bearSkin = (R.drawable.ic_bear_head_04)
-            }
-
-            if (time) {
-                bearFace = R.drawable.ic_msg_bear_face_good
-                if (fineDustLevel == "나쁨" || fineDustLevel == "매우나쁨") {
-                    bearFace = R.drawable.ic_msg_bear_face_bad
-                }
-                if (weather == "SNOW" || weather == "HEAVY_SNOW") {
-                    bearSnow = (R.drawable.ic_msg_bear_head_snow)
-                    if (fineDustLevel == "좋음") {
-                        bearSnow = (R.drawable.ic_msg_bear_head_snow_good)
-                    }
-                } else
-                    bearSnow = (R.drawable.ic_msg_bear_head_snow_none)
-            } else {
-                bearFace = R.drawable.ic_msg_bear_face_sleep
-                bearSnow = (R.drawable.ic_msg_bear_head_snow_none)
-            }
-
-            // Construct the RemoteViews object
-            val BearHeadview = RemoteViews(context.packageName, R.layout.weather_bear_head_widget)
-
-            BearHeadview.setImageViewResource(R.id.widgetBearHeadBase, bearSkin)
-            BearHeadview.setImageViewResource(R.id.widgetBearFace, bearFace)
-            BearHeadview.setImageViewResource(R.id.widgetBearFaceSnow, bearSnow)
-
-            // Instruct the widget manager to update the widget
-            appWidgetManager.updateAppWidget(appWidgetId, BearHeadview)
+        bearSkin = when (fineDustLevel) {
+            WdgFineDustLvl.GOOD -> (R.drawable.ic_bear_head_01)
+            WdgFineDustLvl.NORMAL -> (R.drawable.ic_bear_head_02)
+            WdgFineDustLvl.BAD -> (R.drawable.ic_bear_head_03)
+            WdgFineDustLvl.WORST -> (R.drawable.ic_bear_head_04)
+            else -> (R.drawable.ic_bear_head_01) //unknown
         }
+
+        if (time) {
+            bearFace = R.drawable.ic_msg_bear_face_good
+            if (fineDustLevel == WdgFineDustLvl.BAD || fineDustLevel == WdgFineDustLvl.WORST) {
+                bearFace = R.drawable.ic_msg_bear_face_bad
+            }
+            if (weather == WdgWeather.SNOW) {
+                bearSnow = (R.drawable.ic_msg_bear_head_snow)
+                if (fineDustLevel == WdgFineDustLvl.GOOD) {
+                    bearSnow = (R.drawable.ic_msg_bear_head_snow_good)
+                }
+            } else
+                bearSnow = (R.drawable.ic_msg_bear_head_snow_none)
+        } else {
+            bearFace = R.drawable.ic_msg_bear_face_sleep
+            bearSnow = (R.drawable.ic_msg_bear_head_snow_none)
+        }
+
+        // Construct the RemoteViews object
+        val BearHeadview = RemoteViews(context.packageName, R.layout.weather_bear_head_widget)
+
+        BearHeadview.setImageViewResource(R.id.widgetBearHeadBase, bearSkin)
+        BearHeadview.setImageViewResource(R.id.widgetBearFace, bearFace)
+        BearHeadview.setImageViewResource(R.id.widgetBearFaceSnow, bearSnow)
+
+        // Instruct the widget manager to update the widget
+        appWidgetManager.updateAppWidget(appWidgetId, BearHeadview)
     }
 }
 

--- a/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearHeadWidgetBg.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearHeadWidgetBg.kt
@@ -2,7 +2,6 @@ package com.mashupgroup.weatherbear.widget
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
-import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
@@ -14,34 +13,16 @@ import java.util.*
 /**
  * Implementation of App Widget functionality.
  */
-class WeatherBearHeadWidgetBg : AppWidgetProvider() {
+class WeatherBearHeadWidgetBg : WeatherBearWidgetCommon() {
 
-    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
-        var weather = "HEAVY_SNOW"
-        var fineDustLevel = "좋음"
-        // There may be multiple widgets active, so update all of them
-        for (appWidgetId in appWidgetIds) updateAppWidget(context,
-                appWidgetManager, appWidgetId,
-                weather, fineDustLevel)
-    }
-
-    override fun onEnabled(context: Context) {
-        // Enter relevant functionality for when the first widget is created
-    }
-
-    override fun onDisabled(context: Context) {
-        // Enter relevant functionality for when the last widget is disabled
-    }
-
-    internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager,
-                                 appWidgetId: Int, nWeather: String, nFineDustLevel: String) {
+    override fun updateAppWidget(weatherData : WidgetWeatherData, context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
 
 
         //SNOW, RAINY, THUNDER_RAINY, WIND, CLOUD, SUNNY, HEAVY_SNOW
         //미세먼지 : 좋음,보통,나쁨.매우나쁨
         //낮:true 밤:false
-        val weather = nWeather
-        val fineDustLevel = nFineDustLevel
+        val weather = weatherData.weather
+        val fineDustLevel = weatherData.fineDustLevel
         var time = true
         val date = Date().hours
         time = date in 6..17
@@ -58,21 +39,22 @@ class WeatherBearHeadWidgetBg : AppWidgetProvider() {
         remoteViews.setOnClickPendingIntent(R.id.widgetBearHead, pendingIntent)
         appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
 
-        when (fineDustLevel) {
-            "좋음" -> bearSkin = (R.drawable.ic_bear_head_01)
-            "보통" -> bearSkin = (R.drawable.ic_bear_head_02)
-            "나쁨" -> bearSkin = (R.drawable.ic_bear_head_03)
-            "매우나쁨" -> bearSkin = (R.drawable.ic_bear_head_04)
+        bearSkin = when (fineDustLevel) {
+            WdgFineDustLvl.GOOD -> (R.drawable.ic_bear_head_01)
+            WdgFineDustLvl.NORMAL -> (R.drawable.ic_bear_head_02)
+            WdgFineDustLvl.BAD -> (R.drawable.ic_bear_head_03)
+            WdgFineDustLvl.WORST -> (R.drawable.ic_bear_head_04)
+            else -> (R.drawable.ic_bear_head_01) //unknown
         }
 
         if (time) {
             bearFace = R.drawable.ic_msg_bear_face_good
-            if (fineDustLevel == "나쁨" || fineDustLevel == "매우나쁨") {
+            if (fineDustLevel == WdgFineDustLvl.BAD || fineDustLevel == WdgFineDustLvl.WORST) {
                 bearFace = R.drawable.ic_msg_bear_face_bad
             }
-            if (weather == "SNOW" || weather == "HEAVY_SNOW") {
+            if (weather == WdgWeather.SNOW) {
                 bearSnow = (R.drawable.ic_msg_bear_head_snow)
-                if (fineDustLevel == "좋음") {
+                if (fineDustLevel == WdgFineDustLvl.GOOD) {
                     bearSnow = (R.drawable.ic_msg_bear_head_snow_good)
                 }
             } else

--- a/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearWidgetCommon.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearWidgetCommon.kt
@@ -74,12 +74,13 @@ abstract class WeatherBearWidgetCommon : AppWidgetProvider() {
                 updateWeatherData(widgetWeatherData)
             }
 
-            // 저장된 장소가 있으므로 장소 가져옴
+            // 저장된 장소가 있으므로 장소(첫번째꺼) 가져옴
             val addrFirst: Address = addrList[0]
             val location = Location(LocationManager.GPS_PROVIDER)
             location.latitude = addrFirst.latitude
             location.longitude = addrFirst.longitude
-            widgetWeatherData.locationText = Global.createLocationString(addrFirst, false)
+            widgetWeatherData.locationText = Global.getSmallestLocationString(addrFirst)
+
             requestDataFromServer(widgetWeatherData, location)
 
         } else {

--- a/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearWidgetCommon.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearWidgetCommon.kt
@@ -84,28 +84,26 @@ abstract class WeatherBearWidgetCommon : AppWidgetProvider() {
             requestDataFromServer(widgetWeatherData, location)
 
         } else {
+            // 저장된 장소가 없으므로 no data 처리
             widgetWeatherData.isDustLevelUpdated = true
             widgetWeatherData.isWeatherUpdated = true
-            // 저장된 장소가 없으므로 no data 처리
             updateWeatherData(widgetWeatherData)
         }
     }
 
     private fun updateWeatherData(data: WidgetWeatherData) {
         if(savedContext == null || savedAppWidgetManager == null || savedAppWidgetIds == null) return
-
-        // 데이터 업데이트 다 됐는지 확인
-        if(!(data.isDustLevelUpdated && data.isWeatherUpdated)) {
-            return  // 미세먼지와 날씨 둘 다 불러온상태가 아니면 무시데쓰요
-        }
+        // 날씨 업데이트되면 한번, 미세먼지 업데이트되면 한번 해서 총 두번 호출될것임
 
         for (appWidgetId in savedAppWidgetIds!!)         // 모든 활성화된 위젯 업데이트
             updateAppWidget(data, savedContext!!, savedAppWidgetManager!!, appWidgetId)
 
-        // 저장된 임시객체 메모리해제
-        savedAppWidgetIds = null
-        savedAppWidgetManager = null
-        savedContext = null
+        // 저장된 임시객체 메모리해제(모든 데이터가 다 불러와졌을때)
+        if(data.isWeatherUpdated && data.isDustLevelUpdated) {
+            savedAppWidgetIds = null
+            savedAppWidgetManager = null
+            savedContext = null
+        }
     }
 
     @SuppressLint("CheckResult")
@@ -136,6 +134,7 @@ abstract class WeatherBearWidgetCommon : AppWidgetProvider() {
                                  else data.weather = WdgWeather.CLOUDY
                             else -> data.weather = WdgWeather.SUNNY
                         }
+                        data.temperature = (it.main.temp - 273.15).toInt()
                         updateWeatherData(data)
                     }
                 }, { err -> err.printStackTrace() })

--- a/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearWidgetCommon.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBearWidgetCommon.kt
@@ -1,0 +1,194 @@
+package com.mashupgroup.weatherbear.widget
+
+import android.annotation.SuppressLint
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.Context
+import android.location.Address
+import android.location.Location
+import android.location.LocationManager
+import android.util.Log
+import com.mashupgroup.weatherbear.*
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.schedulers.Schedulers
+
+abstract class WeatherBearWidgetCommon : AppWidgetProvider() {
+    /* API */
+    private val weatherApiToken = BuildConfig.WEATHER_API_TOKEN
+    private val airApiToken = BuildConfig.AIR_API_TOKEN
+    private val kakaoApiToken = BuildConfig.KAKAO_API_TOKEN
+    private val airAPI = AirAPI()
+    private val airStationRetrofit = airAPI.createStationInfoRetrofit()
+    private val airStationInterface = airStationRetrofit.create(AirInterface::class.java)
+    private val airRetrofit = airAPI.createAirInfoRetrofit()
+    private val airInterface = airRetrofit.create(AirInterface::class.java)
+    private val weatherAPI = WeatherAPI()
+    private val weatherRetrofit = weatherAPI.createWeatherRetrofit()
+    private val weatherInterface = weatherRetrofit.create(WeatherInterface::class.java)
+    private val kakaoAPI = KakaoAPI()
+    private val kakaoRetrofit = kakaoAPI.createTransRetrofit()
+    private val kakaoInterface = kakaoRetrofit.create(KakaoInterface::class.java)
+
+    enum class WdgFineDustLvl { GOOD, NORMAL, BAD, WORST, NO_DATA }
+    enum class WdgWeather { SUNNY, SNOW, RAIN, CLOUDY, THUNDER, NO_DATA }
+
+    // 정보 갱신동안 저장할 context, appWidgetManager, appWidgetIds
+    // 얘들은 updateAppWidget 최종호출시점때 null로 메모리 해제되어야한다.
+    private var savedContext: Context? = null
+    private var savedAppWidgetManager: AppWidgetManager? = null
+    private var savedAppWidgetIds: IntArray? = null
+    /* 사실 위 방법이 좋은건 아닌거같은데, 이 3개를 일일이 매개변수로 넘겨주는 것 보단 덜 귀찮을거같아서 이렇게 했어.
+       null-check 를 하지만 null-safe 한거는 아니야. 구조체로 묶는것도 좀 오바인거같고. 더 나은방법 없을까..? */
+
+    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+        // 임시 객체 저장
+        savedContext = context
+        savedAppWidgetManager = appWidgetManager
+        savedAppWidgetIds = appWidgetIds
+
+        // 날씨 정보 갱신
+        requestWeatherData()
+    }
+
+    abstract fun updateAppWidget(weatherData : WidgetWeatherData,
+                                 context: Context,
+                                 appWidgetManager: AppWidgetManager,
+                                 appWidgetId: Int)
+
+    private fun requestWeatherData() {
+        if(savedContext == null || savedAppWidgetManager == null || savedAppWidgetIds == null) return
+
+        val widgetWeatherData = WidgetWeatherData(
+                WdgWeather.NO_DATA,
+                WdgFineDustLvl.NO_DATA,
+                savedContext!!.getString(R.string.noData),
+                0)
+
+        // 저장된 장소중 첫번째 가져오기
+        if(Global.loadAddressList() != null) {
+            val addrList = Global.loadAddressList()
+            if(addrList!!.isEmpty()) {
+                // 저장된 장소가 없으므로 no data 처리
+                widgetWeatherData.isDustLevelUpdated = true
+                widgetWeatherData.isWeatherUpdated = true
+                updateWeatherData(widgetWeatherData)
+            }
+
+            // 저장된 장소가 있으므로 장소 가져옴
+            val addrFirst: Address = addrList[0]
+            val location = Location(LocationManager.GPS_PROVIDER)
+            location.latitude = addrFirst.latitude
+            location.longitude = addrFirst.longitude
+            widgetWeatherData.locationText = Global.createLocationString(addrFirst, false)
+            requestDataFromServer(widgetWeatherData, location)
+
+        } else {
+            widgetWeatherData.isDustLevelUpdated = true
+            widgetWeatherData.isWeatherUpdated = true
+            // 저장된 장소가 없으므로 no data 처리
+            updateWeatherData(widgetWeatherData)
+        }
+    }
+
+    private fun updateWeatherData(data: WidgetWeatherData) {
+        if(savedContext == null || savedAppWidgetManager == null || savedAppWidgetIds == null) return
+
+        // 데이터 업데이트 다 됐는지 확인
+        if(!(data.isDustLevelUpdated && data.isWeatherUpdated)) {
+            return  // 미세먼지와 날씨 둘 다 불러온상태가 아니면 무시데쓰요
+        }
+
+        for (appWidgetId in savedAppWidgetIds!!)         // 모든 활성화된 위젯 업데이트
+            updateAppWidget(data, savedContext!!, savedAppWidgetManager!!, appWidgetId)
+
+        // 저장된 임시객체 메모리해제
+        savedAppWidgetIds = null
+        savedAppWidgetManager = null
+        savedContext = null
+    }
+
+    @SuppressLint("CheckResult")
+    private fun requestDataFromServer(data: WidgetWeatherData, location: Location) {
+        if(savedContext == null || savedAppWidgetManager == null || savedAppWidgetIds == null) return
+
+        /* Get TM Postion */
+        kakaoInterface.getPos(kakaoApiToken, location.longitude, location.latitude, "WGS84", "TM")
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe( { coord -> coord?.let { requestStationInfo(data, coord.documents[0].x, coord.documents[0].y, savedContext!!) } },
+                            { err -> err.printStackTrace() })
+
+        /* Get WdgWeather */
+        weatherInterface.getWeather(location.latitude, location.longitude, weatherApiToken)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe( { weatherInfo ->
+                    weatherInfo?.let {
+                        data.isWeatherUpdated = true
+                        val weatherId = it.weather[0].id
+                        when (weatherId / 100) {
+                            2 -> data.weather = WdgWeather.THUNDER
+                            3 -> data.weather = WdgWeather.RAIN
+                            6 -> data.weather = WdgWeather.SNOW
+                            7 -> data.weather = WdgWeather.CLOUDY
+                            8 -> if (weatherId == 800) data.weather = WdgWeather.SUNNY
+                                 else data.weather = WdgWeather.CLOUDY
+                            else -> data.weather = WdgWeather.SUNNY
+                        }
+                        updateWeatherData(data)
+                    }
+                }, { err -> err.printStackTrace() })
+    }
+
+    @SuppressLint("CheckResult")
+    private fun requestStationInfo(data: WidgetWeatherData, tmX: String, tmY: String, context: Context) {
+        if(savedContext == null || savedAppWidgetManager == null || savedAppWidgetIds == null) return
+
+        /* Get StationInfo */
+        airStationInterface.getStation("json", tmX, tmY, airApiToken)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe( { stationInfo -> stationInfo?.let{ station -> requestAirInfo(data, station.list[0].stationName, context) } },
+                            { err -> err.printStackTrace() })
+    }
+
+    @SuppressLint("CheckResult")
+    private fun requestAirInfo(data: WidgetWeatherData, stationName: String, context: Context) {
+        if(savedContext == null || savedAppWidgetManager == null || savedAppWidgetIds == null) return
+
+        /* Get AirInfo */
+        airInterface.getAir(context.getString(R.string.api_json), 1, stationName, context.getString(R.string.api_daily), 1.3, airApiToken)
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe({ airInfo ->
+                    data.isDustLevelUpdated = true
+                    Log.v("requestAirInfo", "$stationName : $airInfo")
+                    val ultraDust = airInfo.list[0].pm10Value.toInt()
+                    data.fineDustLevel =
+                            when {
+                                ultraDust < 16 -> WdgFineDustLvl.GOOD
+                                ultraDust in 16..50 -> WdgFineDustLvl.NORMAL
+                                ultraDust in 51..100 -> WdgFineDustLvl.BAD
+                                else -> WdgFineDustLvl.WORST
+                            }
+                    updateWeatherData(data)
+
+                }, { err -> err.printStackTrace() })
+    }
+
+    override fun onEnabled(context: Context) {
+        // Enter relevant functionality for when the first widget is created
+    }
+
+    override fun onDisabled(context: Context) {
+        // Enter relevant functionality for when the last widget is disabled
+    }
+
+    data class WidgetWeatherData(var weather: WdgWeather,
+                                 var fineDustLevel: WdgFineDustLvl,
+                                 var locationText: String,
+                                 var temperature: Int) {
+        var isWeatherUpdated = false
+        var isDustLevelUpdated = false
+    }
+}

--- a/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBoxWidget.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBoxWidget.kt
@@ -2,7 +2,6 @@ package com.mashupgroup.weatherbear.widget
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
-import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
@@ -14,113 +13,100 @@ import java.util.*
 /**
  * Implementation of App Widget functionality.
  */
-class WeatherBoxWidget : AppWidgetProvider() {
+class WeatherBoxWidget : WeatherBearWidgetCommon() {
 
-    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
+    override fun updateAppWidget(weatherData : WidgetWeatherData, context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
 
-        var weather = "SNOW"
+        //홈스크린의 위젯 xml에 대한 인스턴스를 받아온다,
+        val remoteViews = RemoteViews(context.packageName, R.layout.weather_box_widget)
+        //main activity와 위젯간 데이터 교환의 매개채
+        val intent = Intent(context, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(context,0,intent,0)
+        remoteViews.setOnClickPendingIntent(R.id.widgetBearFace,pendingIntent)
+        remoteViews.setOnClickPendingIntent(R.id.tvWidgetLocation,pendingIntent)
+        remoteViews.setOnClickPendingIntent(R.id.tvWidgetTemperature
+                ,pendingIntent)
+        remoteViews.setOnClickPendingIntent(R.id.tvWidgetFineDust,pendingIntent)
+        remoteViews.setOnClickPendingIntent(R.id.tvWidgetWeather,pendingIntent)
+        appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
+
+        //SNOW, RAINY, THUNDER_RAINY, WIND, CLOUD, SUNNY, HEAVY_SNOW
+        val weather = weatherData.weather
         //좋음,보통,나쁨.매우나쁨
-        var fineDustLevel = "매우나쁨"
-        var locationText = "서울시 중구"
-        var temperature = -13
+        val fineDustLevel = weatherData.fineDustLevel
+        val locationText = weatherData.locationText
+        val temperature = weatherData.temperature.toString()
 
-        // There may be multiple widgets active, so update all of them
-        for (appWidgetId in appWidgetIds) {
-            updateAppWidget(context, appWidgetManager, appWidgetId, weather, fineDustLevel,
-                    locationText, temperature)
-        }
-    }
+        var bearSkin = R.drawable.ic_bear_head_01
+        var bearSnow = R.drawable.ic_msg_bear_head_snow_good
+        var bearFace: Int
+        //낮:true 밤:false
+        var time = true
+        val date = Date().hours
+        time = date in 6..17
 
-    override fun onEnabled(context: Context) {
-        // Enter relevant functionality for when the first widget is created
-    }
+        bearSnow = bearHeadFace(fineDustLevel, weather, time)
 
-    override fun onDisabled(context: Context) {
-        // Enter relevant functionality for when the last widget is disabled
-    }
-
-    companion object {
-
-        internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager,
-                                     appWidgetId: Int, nWeather: String, nFineDustLevel: String,
-                                     nLocationText: String, nTemperature: Int) {
-
-            //홈스크린의 위젯 xml에 대한 인스턴스를 받아온다,
-            val remoteViews = RemoteViews(context.packageName, R.layout.weather_box_widget)
-            //main activity와 위젯간 데이터 교환의 매개채
-            val intent = Intent(context, MainActivity::class.java)
-            val pendingIntent = PendingIntent.getActivity(context,0,intent,0)
-            remoteViews.setOnClickPendingIntent(R.id.widgetBearFace,pendingIntent)
-            remoteViews.setOnClickPendingIntent(R.id.tvWidgetLocation,pendingIntent)
-            remoteViews.setOnClickPendingIntent(R.id.tvWidgetTemperature
-                    ,pendingIntent)
-            remoteViews.setOnClickPendingIntent(R.id.tvWidgetFineDust,pendingIntent)
-            remoteViews.setOnClickPendingIntent(R.id.tvWidgetWeather,pendingIntent)
-            appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
-
-            //SNOW, RAINY, THUNDER_RAINY, WIND, CLOUD, SUNNY, HEAVY_SNOW
-            val weather = nWeather
-            //좋음,보통,나쁨.매우나쁨
-            val fineDustLevel = nFineDustLevel
-            val locationText = nLocationText
-            val temperature = nTemperature.toString()
-
-            var bearSkin = R.drawable.ic_bear_head_01
-            var bearSnow = R.drawable.ic_msg_bear_head_snow_good
-            var bearFace: Int
-            //낮:true 밤:false
-            var time = true
-            val date = Date().hours
-            time = date in 6..17
-
-            bearSnow = bearHeadFace(fineDustLevel, weather, time)
-
-            when (fineDustLevel) {
-                "좋음" -> bearSkin = (R.drawable.ic_bear_head_01)
-                "보통" -> bearSkin = (R.drawable.ic_bear_head_02)
-                "나쁨" -> bearSkin = (R.drawable.ic_bear_head_03)
-                "매우나쁨" -> bearSkin = (R.drawable.ic_bear_head_04)
-            }
-
-            if (time) {
-                bearFace = R.drawable.ic_msg_bear_face_good
-                if (fineDustLevel == "나쁨" || fineDustLevel == "매우나쁨")
-                    bearFace = R.drawable.ic_msg_bear_face_bad
-            } else {
-                bearFace = R.drawable.ic_msg_bear_face_sleep
-            }
-
-
-            val weatherBox = RemoteViews(context.packageName, R.layout.weather_box_widget)
-
-            weatherBox.setImageViewResource(R.id.widgetBearHeadBase, bearSkin)
-            weatherBox.setImageViewResource(R.id.widgetBearFace, bearFace)
-            weatherBox.setImageViewResource(R.id.widgetBearFaceSnow, bearSnow)
-
-            weatherBox.setTextViewText(R.id.tvWidgetFineDust, fineDustLevel)
-            weatherBox.setTextViewText(R.id.tvWidgetLocation, locationText)
-            weatherBox.setTextViewText(R.id.tvWidgetTemperature, temperature)
-            weatherBox.setTextViewText(R.id.tvWidgetWeather, weather)
-
-            // Instruct the widget manager to update the widget
-            appWidgetManager.updateAppWidget(appWidgetId, weatherBox)
+        bearSkin = when (fineDustLevel) {
+            WdgFineDustLvl.GOOD -> (R.drawable.ic_bear_head_01)
+            WdgFineDustLvl.NORMAL -> (R.drawable.ic_bear_head_02)
+            WdgFineDustLvl.BAD -> (R.drawable.ic_bear_head_03)
+            WdgFineDustLvl.WORST -> (R.drawable.ic_bear_head_04)
+            else -> (R.drawable.ic_bear_head_01) //unknown
         }
 
-        private fun bearHeadFace(fineDustLevel: String, weather: String, time: Boolean): Int {
-            if (time) {
-                if (weather == "SNOW" || weather == "HEAVY_SNOW") {
-                    return if (fineDustLevel == "좋음") {
-                        (R.drawable.ic_msg_bear_head_snow_good)
-                    } else
-                        (R.drawable.ic_msg_bear_head_snow)
-                }
-                return (R.drawable.ic_msg_bear_head_snow_none)
-            } else {
-                return (R.drawable.ic_msg_bear_head_snow_none)
-            }
-
+        if (time) {
+            bearFace = R.drawable.ic_msg_bear_face_good
+            if (fineDustLevel == WdgFineDustLvl.BAD || fineDustLevel == WdgFineDustLvl.WORST)
+                bearFace = R.drawable.ic_msg_bear_face_bad
+        } else {
+            bearFace = R.drawable.ic_msg_bear_face_sleep
         }
 
+
+        val weatherBox = RemoteViews(context.packageName, R.layout.weather_box_widget)
+
+        weatherBox.setImageViewResource(R.id.widgetBearHeadBase, bearSkin)
+        weatherBox.setImageViewResource(R.id.widgetBearFace, bearFace)
+        weatherBox.setImageViewResource(R.id.widgetBearFaceSnow, bearSnow)
+
+        val weatherText = when(weatherData.weather) {
+            WdgWeather.SUNNY -> context.getString(R.string.msg_sunny)
+            WdgWeather.SNOW -> context.getString(R.string.msg_snow)
+            WdgWeather.RAIN -> context.getString(R.string.msg_rain)
+            WdgWeather.CLOUDY -> context.getString(R.string.msg_cloud)
+            WdgWeather.THUNDER -> context.getString(R.string.msg_thunder)
+            WdgWeather.NO_DATA -> context.getString(R.string.noData)
+        }
+        val fineDustLevelText = when(weatherData.fineDustLevel) {
+            WdgFineDustLvl.GOOD -> context.getString(R.string.fine_dust_good)
+            WdgFineDustLvl.NORMAL -> context.getString(R.string.fine_dust_normal)
+            WdgFineDustLvl.BAD -> context.getString(R.string.fine_dust_bad)
+            WdgFineDustLvl.WORST -> context.getString(R.string.fine_dust_very_bad)
+            WdgFineDustLvl.NO_DATA -> context.getString(R.string.noData)
+        }
+
+        weatherBox.setTextViewText(R.id.tvWidgetFineDust, fineDustLevelText)
+        weatherBox.setTextViewText(R.id.tvWidgetLocation, locationText)
+        weatherBox.setTextViewText(R.id.tvWidgetTemperature, temperature)
+        weatherBox.setTextViewText(R.id.tvWidgetWeather, weatherText)
+
+        // Instruct the widget manager to update the widget
+        appWidgetManager.updateAppWidget(appWidgetId, weatherBox)
+    }
+
+    private fun bearHeadFace(fineDustLevel: WdgFineDustLvl, weather: WdgWeather, time: Boolean): Int {
+        if (time) {
+            if (weather == WdgWeather.SNOW) {
+                return if (fineDustLevel == WdgFineDustLvl.GOOD) {
+                    (R.drawable.ic_msg_bear_head_snow_good)
+                } else
+                    (R.drawable.ic_msg_bear_head_snow)
+            }
+            return (R.drawable.ic_msg_bear_head_snow_none)
+        } else {
+            return (R.drawable.ic_msg_bear_head_snow_none)
+        }
     }
 }
 

--- a/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBoxWidgetBg.kt
+++ b/app/src/main/java/com/mashupgroup/weatherbear/widget/WeatherBoxWidgetBg.kt
@@ -2,7 +2,6 @@ package com.mashupgroup.weatherbear.widget
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
-import android.appwidget.AppWidgetProvider
 import android.content.Context
 import android.content.Intent
 import android.widget.RemoteViews
@@ -14,112 +13,102 @@ import java.util.*
 /**
  * Implementation of App Widget functionality.
  */
-class WeatherBoxWidgetBg : AppWidgetProvider() {
+class WeatherBoxWidgetBg : WeatherBearWidgetCommon() {
 
-    override fun onUpdate(context: Context, appWidgetManager: AppWidgetManager, appWidgetIds: IntArray) {
-        var weather = "SNOW"
+    override fun updateAppWidget(weatherData : WidgetWeatherData, context: Context, appWidgetManager: AppWidgetManager, appWidgetId: Int) {
+
+        //홈스크린의 위젯 xml에 대한 인스턴스를 받아온다,
+        val remoteViews = RemoteViews(context.packageName, R.layout.weather_box_widget_bg)
+        //main activity와 위젯간 데이터 교환의 매개채
+        val intent = Intent(context, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(context,0,intent,0)
+        remoteViews.setOnClickPendingIntent(R.id.widgetBearFace,pendingIntent)
+        remoteViews.setOnClickPendingIntent(R.id.tvWidgetLocation,pendingIntent)
+        remoteViews.setOnClickPendingIntent(R.id.tvWidgetTemperature
+                ,pendingIntent)
+        remoteViews.setOnClickPendingIntent(R.id.tvWidgetFineDust,pendingIntent)
+        remoteViews.setOnClickPendingIntent(R.id.tvWidgetWeather,pendingIntent)
+        appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
+
+
+        //SNOW, RAINY, THUNDER_RAINY, WIND, CLOUD, SUNNY, HEAVY_SNOW
+        val weather = weatherData.weather
         //좋음,보통,나쁨.매우나쁨
-        var fineDustLevel = "나쁨"
-        var locationText = "서울시 강남  구"
-        var temperature = -12
+        val fineDustLevel = weatherData.fineDustLevel
+        val locationText = weatherData.locationText
+        val temperature = weatherData.temperature.toString()
 
+        var bearSkin = R.drawable.ic_bear_head_01
+        var bearSnow = R.drawable.ic_msg_bear_head_snow_good
+        var bearFace: Int
+        //낮:true 밤:false
+        var time = true
+        val date = Date().hours
+        time = date in 6..17
 
-        for (appWidgetId in appWidgetIds) {
-            updateAppWidget(context, appWidgetManager, appWidgetId,weather, fineDustLevel,
-                    locationText, temperature)
-        }
-    }
+        bearSnow = bearHeadFace(fineDustLevel, weather, time)
 
-    override fun onEnabled(context: Context) {
-        // Enter relevant functionality for when the first widget is created
-    }
-
-    override fun onDisabled(context: Context) {
-        // Enter relevant functionality for when the last widget is disabled
-    }
-
-    companion object {
-
-        internal fun updateAppWidget(context: Context, appWidgetManager: AppWidgetManager,
-                                     appWidgetId: Int, nWeather: String, nFineDustLevel: String,
-                                     nLocationText: String, nTemperature: Int) {
-
-            //홈스크린의 위젯 xml에 대한 인스턴스를 받아온다,
-            val remoteViews = RemoteViews(context.packageName, R.layout.weather_box_widget_bg)
-            //main activity와 위젯간 데이터 교환의 매개채
-            val intent = Intent(context, MainActivity::class.java)
-            val pendingIntent = PendingIntent.getActivity(context,0,intent,0)
-            remoteViews.setOnClickPendingIntent(R.id.widgetBearFace,pendingIntent)
-            remoteViews.setOnClickPendingIntent(R.id.tvWidgetLocation,pendingIntent)
-            remoteViews.setOnClickPendingIntent(R.id.tvWidgetTemperature
-                    ,pendingIntent)
-            remoteViews.setOnClickPendingIntent(R.id.tvWidgetFineDust,pendingIntent)
-            remoteViews.setOnClickPendingIntent(R.id.tvWidgetWeather,pendingIntent)
-            appWidgetManager.updateAppWidget(appWidgetId, remoteViews)
-
-
-            //SNOW, RAINY, THUNDER_RAINY, WIND, CLOUD, SUNNY, HEAVY_SNOW
-            val weather = nWeather
-            //좋음,보통,나쁨.매우나쁨
-            val fineDustLevel = nFineDustLevel
-            val locationText = nLocationText
-            val temperature = nTemperature.toString()
-
-            var bearSkin = R.drawable.ic_bear_head_01
-            var bearSnow = R.drawable.ic_msg_bear_head_snow_good
-            var bearFace: Int
-            //낮:true 밤:false
-            var time = true
-            val date = Date().hours
-            time = date in 6..17
-
-            bearSnow = bearHeadFace(fineDustLevel, weather, time)
-
-            when (fineDustLevel) {
-                "좋음" -> bearSkin = (R.drawable.ic_bear_head_01)
-                "보통" -> bearSkin = (R.drawable.ic_bear_head_02)
-                "나쁨" -> bearSkin = (R.drawable.ic_bear_head_03)
-                "매우나쁨" -> bearSkin = (R.drawable.ic_bear_head_04)
-            }
-
-            if (time) {
-                bearFace = R.drawable.ic_msg_bear_face_good
-                if (fineDustLevel == "나쁨" || fineDustLevel == "매우나쁨")
-                    bearFace = R.drawable.ic_msg_bear_face_bad
-            } else {
-                bearFace = R.drawable.ic_msg_bear_face_sleep
-            }
-
-
-            val weatherBoxBg = RemoteViews(context.packageName, R.layout.weather_box_widget_bg)
-
-            weatherBoxBg.setImageViewResource(R.id.widgetBearHeadBase, bearSkin)
-            weatherBoxBg.setImageViewResource(R.id.widgetBearFace, bearFace)
-            weatherBoxBg.setImageViewResource(R.id.widgetBearFaceSnow, bearSnow)
-
-            weatherBoxBg.setTextViewText(R.id.tvWidgetFineDust, fineDustLevel)
-            weatherBoxBg.setTextViewText(R.id.tvWidgetLocation, locationText)
-            weatherBoxBg.setTextViewText(R.id.tvWidgetTemperature, temperature)
-            weatherBoxBg.setTextViewText(R.id.tvWidgetWeather, weather)
-
-            // Instruct the widget manager to update the widget
-            appWidgetManager.updateAppWidget(appWidgetId, weatherBoxBg)
+        bearSkin = when (fineDustLevel) {
+            WdgFineDustLvl.GOOD -> (R.drawable.ic_bear_head_01)
+            WdgFineDustLvl.NORMAL -> (R.drawable.ic_bear_head_02)
+            WdgFineDustLvl.BAD -> (R.drawable.ic_bear_head_03)
+            WdgFineDustLvl.WORST -> (R.drawable.ic_bear_head_04)
+            else -> (R.drawable.ic_bear_head_01) //unknown
         }
 
-        private fun bearHeadFace(fineDustLevel: String, weather: String, time: Boolean): Int {
-            if (time) {
-                if (weather == "SNOW" || weather == "HEAVY_SNOW") {
-                    return if (fineDustLevel == "좋음") {
-                        (R.drawable.ic_msg_bear_head_snow_good)
-                    } else
-                        (R.drawable.ic_msg_bear_head_snow)
-                }
-                return (R.drawable.ic_msg_bear_head_snow_none)
-            } else {
-                return (R.drawable.ic_msg_bear_head_snow_none)
-            }
-
+        if (time) {
+            bearFace = R.drawable.ic_msg_bear_face_good
+            if (fineDustLevel == WdgFineDustLvl.BAD || fineDustLevel == WdgFineDustLvl.WORST)
+                bearFace = R.drawable.ic_msg_bear_face_bad
+        } else {
+            bearFace = R.drawable.ic_msg_bear_face_sleep
         }
+
+
+        val weatherBoxBg = RemoteViews(context.packageName, R.layout.weather_box_widget_bg)
+
+        weatherBoxBg.setImageViewResource(R.id.widgetBearHeadBase, bearSkin)
+        weatherBoxBg.setImageViewResource(R.id.widgetBearFace, bearFace)
+        weatherBoxBg.setImageViewResource(R.id.widgetBearFaceSnow, bearSnow)
+
+        val weatherText = when(weatherData.weather) {
+            WdgWeather.SUNNY -> context.getString(R.string.msg_sunny)
+            WdgWeather.SNOW -> context.getString(R.string.msg_snow)
+            WdgWeather.RAIN -> context.getString(R.string.msg_rain)
+            WdgWeather.CLOUDY -> context.getString(R.string.msg_cloud)
+            WdgWeather.THUNDER -> context.getString(R.string.msg_thunder)
+            WdgWeather.NO_DATA -> context.getString(R.string.noData)
+        }
+        val fineDustLevelText = when(weatherData.fineDustLevel) {
+            WdgFineDustLvl.GOOD -> context.getString(R.string.fine_dust_good)
+            WdgFineDustLvl.NORMAL -> context.getString(R.string.fine_dust_normal)
+            WdgFineDustLvl.BAD -> context.getString(R.string.fine_dust_bad)
+            WdgFineDustLvl.WORST -> context.getString(R.string.fine_dust_very_bad)
+            WdgFineDustLvl.NO_DATA -> context.getString(R.string.noData)
+        }
+
+        weatherBoxBg.setTextViewText(R.id.tvWidgetFineDust, fineDustLevelText)
+        weatherBoxBg.setTextViewText(R.id.tvWidgetLocation, locationText)
+        weatherBoxBg.setTextViewText(R.id.tvWidgetTemperature, temperature)
+        weatherBoxBg.setTextViewText(R.id.tvWidgetWeather, weatherText)
+
+        // Instruct the widget manager to update the widget
+        appWidgetManager.updateAppWidget(appWidgetId, weatherBoxBg)
+    }
+
+    private fun bearHeadFace(fineDustLevel: WdgFineDustLvl, weather: WdgWeather, time: Boolean): Int {
+        if (time) {
+            if (weather == WdgWeather.SNOW) {
+                return if (fineDustLevel == WdgFineDustLvl.GOOD) {
+                    (R.drawable.ic_msg_bear_head_snow_good)
+                } else
+                    (R.drawable.ic_msg_bear_head_snow)
+            }
+            return (R.drawable.ic_msg_bear_head_snow_none)
+        } else {
+            return (R.drawable.ic_msg_bear_head_snow_none)
+        }
+
     }
 }
 


### PR DESCRIPTION
1. 위젯 리팩토링했습니다
하나의 WidgetCommon 클래스를 만들었습니다. 여기서는 기본적으로 데이터를 가져와서 갱신요청을 호출합니다.
Common클래스를 상속받은 4개의 위젯 클래스는 실제 뷰를 구현하는 코드가 들어있습니다.

2. 위젯은 위치를 표기하는 칸이 매우 작으므로, 아주 최소한의 행정구역(보통 도시이름)만 나오게끔 했습니다

3. 앱이 종료될 때 위젯을 업데이트합니다. (앱에서 첫번째 도시를 바꿨을 경우 대비)

4. 기타 위젯 버그 수정했습니다.